### PR TITLE
Removing MIT references

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ You can reach the author on github or by email [jarmo.p@gmail.com](mailto:jarmo.
 
 Jarmo Pertman
 
-MIT (see the LICENSE file for details)
+(see the LICENSE file for details)

--- a/lib/require_all.rb
+++ b/lib/require_all.rb
@@ -1,6 +1,5 @@
 #--
 # Copyright (C)2009 Tony Arcieri
-# You can redistribute this under the terms of the MIT license
 # See file LICENSE for details
 #++
 


### PR DESCRIPTION
I saw that you don't consider the project to use the MIT license so I went ahead and updated some places that still said that it did.

Updating the license might still be a good idea, though.