### PR TITLE
License update.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,58 +1,20 @@
-Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.co.jp>.
-You can redistribute it and/or modify it under either the terms of the GPL
-(see COPYING.txt file), or the conditions below:
+Copyright (c) 2009 Jarmo Pertman
 
-  1. You may make and give away verbatim copies of the source form of the
-     software without restriction, provided that you duplicate all of the
-     original copyright notices and associated disclaimers.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-  2. You may modify your copy of the software in any way, provided that
-     you do at least ONE of the following:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-       a) place your modifications in the Public Domain or otherwise
-          make them Freely Available, such as by posting said
-	  modifications to Usenet or an equivalent medium, or by allowing
-	  the author to include your modifications in the software.
-
-       b) use the modified software only within your corporation or
-          organization.
-
-       c) rename any non-standard executables so the names do not conflict
-	  with standard executables, which must also be provided.
-
-       d) make other distribution arrangements with the author.
-
-  3. You may distribute the software in object code or executable
-     form, provided that you do at least ONE of the following:
-
-       a) distribute the executables and library files of the software,
-	  together with instructions (in the manual page or equivalent)
-	  on where to get the original distribution.
-
-       b) accompany the distribution with the machine-readable source of
-	  the software.
-
-       c) give non-standard executables non-standard names, with
-          instructions on where to get the original software distribution.
-
-       d) make other distribution arrangements with the author.
-
-  4. You may modify and include the part of the software into any other
-     software (possibly commercial).  But some files in the distribution
-     are not written by the author, so that they are not under this terms.
-
-     They are gc.c(partly), utils.c(partly), regex.[ch], st.[ch] and some
-     files under the ./missing directory.  See each file for the copying
-     condition.
-
-  5. The scripts and library files supplied as input to or produced as 
-     output from the software do not automatically fall under the
-     copyright of the software, but belong to whomever generated them, 
-     and may be sold commercially, and may be aggregated with this
-     software.
-
-  6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
-     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
-     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-     PURPOSE.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ You can reach the author on github or by email [jarmo.p@gmail.com](mailto:jarmo.
 
 Jarmo Pertman
 
-(see the LICENSE file for details)
+MIT (see the LICENSE file for details)

--- a/lib/require_all.rb
+++ b/lib/require_all.rb
@@ -1,5 +1,6 @@
 #--
 # Copyright (C)2009 Tony Arcieri
+# You can redistribute this under the terms of the MIT license
 # See file LICENSE for details
 #++
 

--- a/require_all.gemspec
+++ b/require_all.gemspec
@@ -9,7 +9,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.homepage = "http://github.com/jarmo/require_all" 
+  s.homepage = "http://github.com/jarmo/require_all"
+  s.license = "MIT" 
 
   s.has_rdoc = true
   s.rdoc_options = %w(--title require_all --main README.md --line-numbers)


### PR DESCRIPTION
It seems that the project was always meant to use the MIT license but had different license text (see #14 and #15). This PR rectifies the inconsistency.

Contributor approval:
- [x] Tony Arcieri
- [x] Jarmo Pertman
- [x] Aaron Klaassen
- [x] Matijs van Zuijlen
- [x] Shota Miyamoto
- [x] Eric Kessler
  
@jarmo @aaronklaassen @mvz @surume Please chime in if you approve of this.

Thanks!