### PR TITLE
Remove unsafe `NameError` retry logic.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+2.0.0:
+
+* Merged PR #24 (https://github.com/jarmo/require_all/pull/24)
+Prior to version 2, RequireAll attempted to automatically resolve dependencies between files, thus
+allowing them to be required in any order. Whilst convenient, the approach used (of rescuing
+`NameError`s and later retrying files that failed to load) was fundamentally unsafe and can result
+in incorrect behaviour (for example issue #8, plus more detail and discussion in #21).
+
 1.5.0:
 
 * Merged PR #13 (https://github.com/jarmo/require_all/pull/13).

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ to the current file (`__FILE__`) as opposed to loading files relative from the w
 
 `load_all` and `load_rel` methods also exist to use `Kernel#load` instead of `Kernel#require`!
 
-The proper order to in which to load files is determined automatically for you.
- 
-It's just that easy!  Code loading shouldn't be hard.
+Files are required in alphabetical order and if there are files in nested directories, they are
+required depth-first. If a `NameError` caused by a reference to an uninitialised constant is
+encountered during the requiring process, then a `RequireAll::RequireError` will be be thrown,
+indicating the file that needs the dependency adding to.
 
 ## autoload_all
 
@@ -98,6 +99,18 @@ autoload_rel "dir2/my_file.rb", base_dir: File.dirname(__FILE__) + "/../dir1"
 
 If having some problems with `autoload_all` or `autoload_rel` then set `$DEBUG=true` to see how files
 are mapped to their respective modules and classes.
+
+## Version compatibility and upgrading
+
+Prior to version 2, RequireAll attempted to automatically resolve dependencies between files, thus
+allowing them to be required in any order. Whilst convenient, the approach used (of rescuing
+`NameError`s and later retrying files that failed to load) was fundamentally unsafe and can result
+in incorrect behaviour (for example issue #8, plus more detail and discussion in #21).
+
+As of version 2, RequireAll will raise a `RequireAll::RequireError` if it encounters a `NameError`
+caused by a reference to an uninitialised constant during the requiring process. As such, it is not
+backwards compatible, but simple to upgrade by adding any requires to load dependencies in files
+that need them.
 
 ## Questions? Comments? Concerns?
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,6 @@
 
 A wonderfully simple way to load your code.
 
-Tired of futzing around with `require` statements everywhere, littering your code
-with `require File.dirname(__FILE__)` crap?  What if you could just 
-point something at a big directory full of code and have everything just 
-automagically load regardless of the dependency structure?  
-
-Wouldn't that be nice?  Well, now you can!
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -105,17 +98,6 @@ autoload_rel "dir2/my_file.rb", base_dir: File.dirname(__FILE__) + "/../dir1"
 
 If having some problems with `autoload_all` or `autoload_rel` then set `$DEBUG=true` to see how files
 are mapped to their respective modules and classes.
-
-## Methodology (except for autoload_{all|rel})
-
-* Enumerate the files to be loaded
-* Try to load all of the files.  If we encounter a `NameError` loading a 
-  particular file, store that file in a "try to load it later" list.
-* If all the files loaded, great, we're done! If not, go through the
-  "try to load it later" list again rescuing `NameError` the same way.
-* If we walk the whole "try to load it later" list and it doesn't shrink
-  at all, we've encountered an unresolvable dependency.  In this case,
-  `require_all` will rethrow the first `NameError` it encountered.
 
 ## Questions? Comments? Concerns?
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to the current file (`__FILE__`) as opposed to loading files relative from the w
 
 Files are required in alphabetical order and if there are files in nested directories, they are
 required depth-first. If a `NameError` caused by a reference to an uninitialised constant is
-encountered during the requiring process, then a `RequireAll::RequireError` will be be thrown,
+encountered during the requiring process, then a `RequireAll::RequireError` will be thrown,
 indicating the file that needs the dependency adding to.
 
 ## autoload_all
@@ -88,7 +88,7 @@ autoload_all File.dirname(__FILE__) + "/dir1"
 autoload_all File.dirname(__FILE__) + "/dir2/my_file.rb",
              base_dir: File.dirname(__FILE__) + "/../dir1"
 ```
-  
+
 * All namespaces will be created dynamically by `autoload_all` - this means that `defined?(Dir1)` will
   return `"constant"` even if `my_file.rb` is not yet loaded!
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 
 A wonderfully simple way to load your code.
 
+Tired of futzing around with `require` statements everywhere, littering your code
+with `require File.dirname(__FILE__)` crap?  What if you could just
+point something at a big directory full of code and have everything just
+automagically load?
+
+Wouldn't that be nice?  Well, now you can!
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -56,7 +63,7 @@ to the current file (`__FILE__`) as opposed to loading files relative from the w
 
 Files are required in alphabetical order and if there are files in nested directories, they are
 required depth-first. If a `NameError` caused by a reference to an uninitialised constant is
-encountered during the requiring process, then a `RequireAll::RequireError` will be thrown,
+encountered during the requiring process, then a `RequireAll::LoadError` will be thrown,
 indicating the file that needs the dependency adding to.
 
 ## autoload_all
@@ -102,15 +109,10 @@ are mapped to their respective modules and classes.
 
 ## Version compatibility and upgrading
 
-Prior to version 2, RequireAll attempted to automatically resolve dependencies between files, thus
-allowing them to be required in any order. Whilst convenient, the approach used (of rescuing
-`NameError`s and later retrying files that failed to load) was fundamentally unsafe and can result
-in incorrect behaviour (for example issue #8, plus more detail and discussion in #21).
-
-As of version 2, RequireAll will raise a `RequireAll::RequireError` if it encounters a `NameError`
+As of version 2, RequireAll will raise a `RequireAll::LoadError` if it encounters a `NameError`
 caused by a reference to an uninitialised constant during the requiring process. As such, it is not
-backwards compatible, but simple to upgrade by adding any requires to load dependencies in files
-that need them.
+backwards compatible with version 1.x, but simple to upgrade by adding any requires to load
+dependencies in files that need them. See [CHANGES] for more details.
 
 ## Questions? Comments? Concerns?
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ are mapped to their respective modules and classes.
 As of version 2, RequireAll will raise a `RequireAll::LoadError` if it encounters a `NameError`
 caused by a reference to an uninitialised constant during the requiring process. As such, it is not
 backwards compatible with version 1.x, but simple to upgrade by adding any requires to load
-dependencies in files that need them. See [CHANGES] for more details.
+dependencies in files that need them. See [CHANGES](CHANGES) for more details.
 
 ## Questions? Comments? Concerns?
 

--- a/lib/require_all.rb
+++ b/lib/require_all.rb
@@ -5,7 +5,7 @@
 #++
 
 module RequireAll
-  RequireError = Class.new(StandardError)
+  LoadError = Class.new(::LoadError)
 
   # A wonderfully simple way to load your code.
   #
@@ -18,7 +18,7 @@ module RequireAll
   # This will find all the .rb files under the lib directory and load them.
   #
   # If a file required by require_all references a constant that is not yet
-  # loaded, a RequireAll::RequireError will be thrown.
+  # loaded, a RequireAll::LoadError will be thrown.
   #
   # You can also give it a glob, which will enumerate all the matching files: 
   #
@@ -99,7 +99,7 @@ module RequireAll
       rescue NameError => e
         # Only wrap NameError exceptions for uninitialized constants
         raise e unless e.instance_of?(NameError) && e.message.include?('uninitialized constant')
-        raise RequireError, "Could not require #{file_} (#{e}). Please require the necessary files"
+        raise LoadError, "Could not require #{file_} (#{e}). Please require the necessary files"
       end
     end
 

--- a/require_all.gemspec
+++ b/require_all.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "require_all"
-  s.version = "1.5.0"
+  s.version = "2.0"
   s.authors = ["Jarmo Pertman", "Tony Arcieri"]
   s.email = "jarmo.p@gmail.com"
   s.summary = "A wonderfully simple way to load your code"

--- a/require_all.gemspec
+++ b/require_all.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "require_all"
-  s.version = "2.0"
+  s.version = "2.0.0"
   s.authors = ["Jarmo Pertman", "Tony Arcieri"]
   s.email = "jarmo.p@gmail.com"
   s.summary = "A wonderfully simple way to load your code"

--- a/spec/fixtures/error/a.rb
+++ b/spec/fixtures/error/a.rb
@@ -1,0 +1,3 @@
+class A
+  non_existent_method
+end

--- a/spec/fixtures/resolvable/a.rb
+++ b/spec/fixtures/resolvable/a.rb
@@ -1,1 +1,3 @@
+require_relative 'c'
+
 class A < C; end

--- a/spec/require_spec.rb
+++ b/spec/require_spec.rb
@@ -14,10 +14,10 @@ describe "require_all" do
   end
 
   context "errors" do
-    it "raises RequireError if files do not declare their dependencies" do
+    it "raises RequireAll:LoadError if files do not declare their dependencies" do
       expect do
         require_all fixture_path('unresolvable/*.rb')
-      end.to raise_error(RequireError) do |error|
+      end.to raise_error(RequireAll::LoadError) do |error|
         expect(error.cause).to be_a NameError
         expect(error.message).to match /Please require the necessary files/
       end

--- a/spec/require_spec.rb
+++ b/spec/require_spec.rb
@@ -5,17 +5,30 @@ describe "require_all" do
 
   subject { self }
 
-  describe "dependency resolution" do
-    it "handles load ordering when dependencies are resolvable" do
+  context "when files correctly declare their dependencies" do
+    it "requires them successfully" do
       require_all fixture_path('resolvable/*.rb')
 
       is_expected.to be_loaded("A", "B", "C", "D")
     end
+  end
 
-    it "raises NameError if dependencies can't be resolved" do
+  context "errors" do
+    it "raises RequireError if files do not declare their dependencies" do
       expect do
         require_all fixture_path('unresolvable/*.rb')
-      end.to raise_error(NameError)
+      end.to raise_error(RequireError) do |error|
+        expect(error.cause).to be_a NameError
+        expect(error.message).to match /Please require the necessary files/
+      end
+    end
+
+    it "raises other NameErrors if encountered" do
+      expect do
+        require_all fixture_path('error')
+      end.to raise_error(NameError) do |error|
+        expect(error.message).to match /undefined local variable or method `non_existent_method'/
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ module SpecHelper
        RelativeA RelativeB RelativeC RelativeD}.each do |const|
       Object.send(:remove_const, const) rescue nil
     end
-    $LOADED_FEATURES.delete_if {|f| f =~ /autoloaded|relative|resolvable/}
+    $LOADED_FEATURES.delete_if {|f| f =~ /autoloaded|error|relative|resolvable/}
   end
 
   def loaded?(*klazzes)


### PR DESCRIPTION
The approach used by RequireAll, of catching `NameError`s and later
retrying files that failed to load, is unsafe. This PR removes it.

More detail in the discussion of PR #21, for adding strict mode.